### PR TITLE
Fix typo of decdede to decoded

### DIFF
--- a/app/auth/application/service/jwt.py
+++ b/app/auth/application/service/jwt.py
@@ -20,14 +20,14 @@ class JwtService(JwtUseCase):
         token: str,
         refresh_token: str,
     ) -> RefreshTokenResponseDTO:
-        decoede_created_token = TokenHelper.decode(token=token)
+        decoded_created_token = TokenHelper.decode(token=token)
         decoded_refresh_token = TokenHelper.decode(token=refresh_token)
         if decoded_refresh_token.get("sub") != "refresh":
             raise DecodeTokenException
 
         return RefreshTokenResponseDTO(
             token=TokenHelper.encode(
-                payload={"user_id": decoede_created_token.get("user_id")}
+                payload={"user_id": decoded_created_token.get("user_id")}
             ),
             refresh_token=TokenHelper.encode(payload={"sub": "refresh"}),
         )


### PR DESCRIPTION
It's maybe tiny change of typo, but It could yield some miss understanding to other programmer, so I recommend to change typo of `decoede_created_token` to `decoded_crated_token`.

If this type of naming is intended, please never mind my pr.

Thanks! Have a good day!